### PR TITLE
Change the maximum amount of devices to 5

### DIFF
--- a/src/main/java/org/whispersystems/textsecuregcm/controllers/DeviceController.java
+++ b/src/main/java/org/whispersystems/textsecuregcm/controllers/DeviceController.java
@@ -62,7 +62,7 @@ public class DeviceController {
 
   private final Logger logger = LoggerFactory.getLogger(DeviceController.class);
 
-  private static final int MAX_DEVICES = 3;
+  private static final int MAX_DEVICES = 5;
 
   private final PendingDevicesManager pendingDevices;
   private final AccountsManager       accounts;


### PR DESCRIPTION
It's 2016. People actually have more than 3 devices these days. A phone, a laptop, a (dual-booted) desktop, another desktop at work and perhaps even a tablet. I would increase the maximum amount of devices even more but I realize that the stability of the service you're running is an important factor here.
