### PR TITLE
Change TextSecure to Signal in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ TextSecure-Server
 =================
 
 The server that handles message routing for the
-[TextSecure](https://github.com/whispersystems/TextSecure/) data channel.  Communication
+[Signal](https://github.com/whispersystems/Signal-Android/) data channel.  Communication
 is handled by a REST API and Push messaging (both GCM and APN).
 
 Documentation


### PR DESCRIPTION
The current link redirects to https://github.com/whispersystems/Signal-Android/ anyway.

// FREEBIE
