### PR TITLE
Allow 9-digit phone numbers

### DIFF
--- a/src/main/java/org/whispersystems/textsecuregcm/util/Util.java
+++ b/src/main/java/org/whispersystems/textsecuregcm/util/Util.java
@@ -43,7 +43,11 @@ public class Util {
   }
 
   public static boolean isValidNumber(String number) {
-    return number.matches("^\\+[0-9]{9,}");
+    return number.matches("^\\+[0-9]{10,}")  ||
+           number.matches("^\\+298[0-9]{6}") ||
+           number.matches("^\\+240[0-9]{6}") ||
+           number.matches("^\\+687[0-9]{6}") ||
+           number.matches("^\\+689[0-9]{6}");
   }
 
   public static String encodeFormParams(Map<String, String> params) {

--- a/src/main/java/org/whispersystems/textsecuregcm/util/Util.java
+++ b/src/main/java/org/whispersystems/textsecuregcm/util/Util.java
@@ -43,7 +43,7 @@ public class Util {
   }
 
   public static boolean isValidNumber(String number) {
-    return number.matches("^\\+[0-9]{10,}");
+    return number.matches("^\\+[0-9]{9,}");
   }
 
   public static String encodeFormParams(Map<String, String> params) {


### PR DESCRIPTION
Faroese phone numbers are 6 digits in length and has a 3-digit dialing
code, but the validation regex requires 10-digit numbers.

This fixes that by changing the requirement to be 9 digits.

Fixes https://github.com/WhisperSystems/Signal-Android/issues/5291