### PR TITLE
NullPointerException might be thrown when closing streams.

### DIFF
--- a/src/main/java/org/whispersystems/textsecuregcm/util/Base64.java
+++ b/src/main/java/org/whispersystems/textsecuregcm/util/Base64.java
@@ -686,10 +686,26 @@ public class Base64
             throw e;
         }   // end catch
         finally {
-            try{ oos.close();   } catch( Exception e ){}
-            try{ gzos.close();  } catch( Exception e ){}
-            try{ b64os.close(); } catch( Exception e ){}
-            try{ baos.close();  } catch( Exception e ){}
+            try {
+                if (oos != null) {
+                    oos.close();
+                }
+            } catch( Exception e ){}
+            try {
+                if (gzos != null) {
+                    gzos.close();
+                }
+            } catch( Exception e ){}
+            try {
+                if (b64os != null) {
+                    b64os.close();
+                }
+            } catch( Exception e ){}
+            try {
+                if (baos != null) {
+                    baos.close();
+                }
+            } catch( Exception e ){}
         }   // end finally
         
         // Return value according to relevant encoding.


### PR DESCRIPTION
Added null check for oos, gzos, b64os, baos before closing.