### PR TITLE
Use Minio instead of the Amazon AWS library

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -64,9 +64,9 @@
         </dependency>
 
         <dependency>
-            <groupId>com.amazonaws</groupId>
-            <artifactId>aws-java-sdk-s3</artifactId>
-            <version>1.10.6</version>
+            <groupId>io.minio</groupId>
+            <artifactId>minio</artifactId>
+            <version>3.0.3</version>
         </dependency>
         <dependency>
             <groupId>com.google.protobuf</groupId>

--- a/src/main/java/org/whispersystems/textsecuregcm/configuration/S3Configuration.java
+++ b/src/main/java/org/whispersystems/textsecuregcm/configuration/S3Configuration.java
@@ -33,9 +33,8 @@ public class S3Configuration {
   @JsonProperty
   private String attachmentsBucket;
 
-  @NotEmpty
   @JsonProperty
-  private String providerUrl;
+  private String providerUrl = "https://s3.amazonaws.com/";
 
   public String getAccessKey() {
     return accessKey;

--- a/src/main/java/org/whispersystems/textsecuregcm/configuration/S3Configuration.java
+++ b/src/main/java/org/whispersystems/textsecuregcm/configuration/S3Configuration.java
@@ -33,6 +33,10 @@ public class S3Configuration {
   @JsonProperty
   private String attachmentsBucket;
 
+  @NotEmpty
+  @JsonProperty
+  private String providerUrl;
+
   public String getAccessKey() {
     return accessKey;
   }
@@ -43,5 +47,9 @@ public class S3Configuration {
 
   public String getAttachmentsBucket() {
     return attachmentsBucket;
+  }
+
+  public String getProviderUrl() {
+    return providerUrl;
   }
 }

--- a/src/main/java/org/whispersystems/textsecuregcm/controllers/FederationControllerV1.java
+++ b/src/main/java/org/whispersystems/textsecuregcm/controllers/FederationControllerV1.java
@@ -70,7 +70,7 @@ public class FederationControllerV1 extends FederationController {
   @Produces(MediaType.APPLICATION_JSON)
   public AttachmentUri getSignedAttachmentUri(@Auth                      FederatedPeer peer,
                                               @PathParam("attachmentId") long attachmentId)
-      throws IOException
+      throws Exception
   {
     return attachmentController.redirectToAttachment(new NonLimitedAccount("Unknown", -1, peer.getName()),
                                                      attachmentId, Optional.<String>absent());


### PR DESCRIPTION
Replace the proprietary Amazon AWS library with the Apache licensed Minio library (https://minio.io/). The Minio library allows to specify a host which exposes an Amazon S3 compatible API, allowing for self-hosting the attachment storage. In order to specify the host a yml configuration option has been added:
```
s3:
  providerUrl: https://s3.amazonaws.com/
```
where that's the URL of the official Amazon service. If `providerUrl` is not specified this default will be used, so this PR doesn't alter the current behavior of Signal-Server.